### PR TITLE
Fixed unexpected hang on doReconfig (2.8.x)

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -70,13 +70,13 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
         self.category = category if callable(
             category) else bytes2unicode(category)
         self.project = bytes2unicode(project)
-        self.initLock = defer.DeferredLock()
+        self.initLock2 = defer.DeferredLock()
 
     def describe(self):
         return "BitbucketPullrequestPoller watching the "\
             "Bitbucket repository {}/{}, branch: {}".format(self.owner, self.slug, self.branch)
 
-    @deferredLocked('initLock')
+    @deferredLocked('initLock2')
     def poll(self):
         d = self._getChanges()
         d.addCallback(self._processChanges)

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -85,7 +85,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         self.category = category if callable(
             category) else bytes2unicode(category)
         self.project = project
-        self.initLock = defer.DeferredLock()
+        self.initLock3 = defer.DeferredLock()
         self.lastRev = {}
         self.revlink_callable = revlink
 
@@ -105,7 +105,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
                  "branches: {}, in workdir '{}' {}").format(self.repourl, ', '.join(self.branches),
                                                             self.workdir, status))
 
-    @deferredLocked('initLock')
+    @deferredLocked('initLock3')
     def poll(self):
         d = self._getChanges()
         d.addCallback(self._processChanges)


### PR DESCRIPTION
`yield self.initLock.acquire()` in doReconfig may hang. Probably `getattr(args[0], lock)` in the decorator @deferredLocked got `self.master.initLock` instead of `self.initLock` somehow in some cases.