### PR TITLE
Fixed unexpected hang on doReconfig (3.x)

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -41,7 +41,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
     def __init__(self, owner, slug, **kwargs):
         kwargs['name'] = self.build_name(owner, slug)
 
-        self.initLock = defer.DeferredLock()
+        self.initLock2 = defer.DeferredLock()
 
         super().__init__(owner, slug, **kwargs)
 
@@ -89,7 +89,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
         return "BitbucketPullrequestPoller watching the "\
             f"Bitbucket repository {self.owner}/{self.slug}, branch: {self.branch}"
 
-    @deferredLocked('initLock')
+    @deferredLocked('initLock2')
     @defer.inlineCallbacks
     def poll(self):
         response = yield self._getChanges()

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -44,7 +44,7 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
             branches = self.build_branches(kwargs.get('branch', None), kwargs.get('branches', None))
             kwargs["name"] = self.build_name(None, repourl, kwargs.get('bookmarks', None), branches)
 
-        self.initLock = defer.DeferredLock()
+        self.initLock3 = defer.DeferredLock()
 
         super().__init__(repourl, **kwargs)
 
@@ -139,7 +139,7 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
         return (f"HgPoller watching the remote Mercurial repository '{self.repourl}', "
                 f"branches: {', '.join(self.branches)}, in workdir '{self.workdir}' {status}")
 
-    @deferredLocked('initLock')
+    @deferredLocked('initLock3')
     @defer.inlineCallbacks
     def poll(self):
         yield self._getChanges()


### PR DESCRIPTION
`yield self.initLock.acquire()` in doReconfig may hang. Probably `getattr(args[0], lock)` in the decorator @deferredLocked got `self.master.initLock` instead of `self.initLock` somehow in some cases.