### PR TITLE
statusToString should be used in all places where we need to get a string representation of the Results.

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -52,6 +52,7 @@ from buildbot.process.results import SKIPPED
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
+from buildbot.process.results import statusToString
 from buildbot.process.results import worst_status
 from buildbot.util import bytes2unicode
 from buildbot.util import debounce
@@ -451,7 +452,7 @@ class BuildStep(results.ResultComputingConfigMixin,
             stepsumm = 'finished'
 
         if self.results != SUCCESS:
-            stepsumm += ' ({})'.format(Results[self.results])
+            stepsumm += ' ({})'.format(statusToString(self.results))
 
         return {'step': stepsumm}
 

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -32,6 +32,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
+from buildbot.process.results import statusToString
 from buildbot.process.results import worst_status
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.util import command_to_string
@@ -177,7 +178,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
 
         if cmdsummary:
             if self.results != SUCCESS:
-                cmdsummary += ' ({})'.format(Results[self.results])
+                cmdsummary += ' ({})'.format(statusToString(self.results))
             return {'step': cmdsummary}
 
         return super(ShellCommand, self).getResultSummary()


### PR DESCRIPTION
For instance this helps to properly handle cases when Results is still None for not yet finished steps.