### PR TITLE
Support the parameter ignoreOfflineWorkersTimeout in master.cfg

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -135,6 +135,10 @@ class MasterConfig(util.ComparableMixin):
         self.titleURL = 'http://buildbot.net'
         self.buildbotURL = 'http://localhost:8080/'
         self.changeHorizon = None
+
+        #LLVM_LOCAL
+        self.ignoreOfflineWorkersTimeout = None
+
         self.logCompressionLimit = 4 * 1024
         self.logCompressionMethod = 'gz'
         self.logEncoding = 'utf-8'
@@ -192,6 +196,7 @@ class MasterConfig(util.ComparableMixin):
         "changeHorizon",
         'db',
         "db_url",
+        "ignoreOfflineWorkersTimeout", #LLVM_LOCAL
         "logCompressionLimit",
         "logCompressionMethod",
         "logEncoding",
@@ -351,6 +356,9 @@ class MasterConfig(util.ComparableMixin):
 
         copy_int_param('changeHorizon')
         copy_int_param('logCompressionLimit')
+
+        #LLVM_LOCAL
+        copy_int_param('ignoreOfflineWorkersTimeout')
 
         self.logCompressionMethod = config_dict.get(
             'logCompressionMethod', 'gz')

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -21,6 +21,7 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot import interfaces
+from buildbot import util
 from buildbot.data import resultspec
 from buildbot.interfaces import IRenderable
 from buildbot.process import buildrequest
@@ -80,6 +81,12 @@ class Builder(util_service.ReconfigurableServiceMixin,
         # Tracks config version for locks
         self.config_version = None
 
+        #LLVM_LOCAL
+        # Do not ignore offline builders within the timeout after reboot.
+        # Use self._last_detached_time=0 to ignore all builders after reboot till attach the first worker.
+        self._last_detached_time = util.now()
+        self._ignore_offline_workers_timeout = None
+
     def _find_builder_config_by_name(self, new_config):
         for builder_config in new_config.builders:
             if builder_config.name == self.name:
@@ -127,6 +134,16 @@ class Builder(util_service.ReconfigurableServiceMixin,
         new_workernames = set(builder_config.workernames)
         self.workers = [w for w in self.workers
                         if w.worker.workername in new_workernames]
+
+        #LLVM_LOCAL
+        # Note ignoreOfflineWorkersTimeout=0 means do not use timeout.
+        self._ignore_offline_workers_timeout = (
+            new_config.ignoreOfflineWorkersTimeout * 60
+            if new_config.ignoreOfflineWorkersTimeout
+            else None
+        )
+        if new_config.ignoreOfflineWorkersTimeout is None:
+            log.msg("WARNING: 'ignoreOfflineWorkersTimeout' is missing in master.cfg")
 
     def _has_updated_config_info(self, old_config, new_config):
         if old_config is None:
@@ -300,6 +317,21 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         # inform the WorkerForBuilder that their worker went away
         wfb.detached()
+
+        #LLVM_LOCAL
+        self._last_detached_time = util.now()
+
+    #LLVM_LOCAL_BEGIN
+    def workersAvailable(self):
+        if (
+            self.workers
+            or self._ignore_offline_workers_timeout is None
+            or self._last_detached_time is None
+        ):
+            return True
+        offline_workers_duration = util.now() - self._last_detached_time
+        return offline_workers_duration < self._ignore_offline_workers_timeout
+    #LLVM_LOCAL_END
 
     def getAvailableWorkers(self):
         return [wfb for wfb in self.workers if wfb.isAvailable()]

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -445,7 +445,13 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
         builderids = []
         for bldr in (yield self.master.data.get(('builders', ))):
             if bldr['name'] in builderNames:
-                builderids.append(bldr['builderid'])
+                #LLVM_LOCAL
+                bldr_obj = self.master.botmaster.builders.get(bldr['name'])
+                # Check the attribute to make tests with mock Builder happy.
+                if not hasattr(bldr_obj.__class__, "workersAvailable") or bldr_obj.workersAvailable():
+                    builderids.append(bldr['builderid'])
+                else:
+                    log.msg(f">>> addBuildsetForSourceStamps: Ignore builder {bldr['name']} because of offline workers.")
 
         # translate properties object into a dict as required by the
         # addBuildset method


### PR DESCRIPTION
`ignoreOfflineWorkersTimeout=60` means do not create build requests for builders which have no active workers more than 60 minutes. 
`ignoreOfflineWorkersTimeout=0` disables this feature.
