### PR TITLE
Improve getPreviousBuild() logic for reporters

### DIFF
--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -22,6 +22,11 @@ from twisted.internet import defer
 
 from buildbot.db import NULL
 from buildbot.db import base
+#LLVM_LOCAL_BEGIN
+from buildbot.process.results import CANCELLED
+from buildbot.process.results import RETRY
+from buildbot.process.results import SKIPPED
+#LLVM_LOCAL_END
 from buildbot.util import epoch2datetime
 
 
@@ -96,6 +101,124 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
 
         return rv
 
+    #LLVM_LOCAL_BEGIN
+    def getPrevBuild(
+        self, builderid: int, number: int, scheduler_filter: str | None = None
+    ) -> defer.Deferred[tuple[int | None, int | None]]:
+        def thd(conn: sa.engine.Connection) -> tuple[int | None, int | None]:
+            builds_tbl = self.db.model.builds
+            if scheduler_filter:
+                buildrequests_tbl = self.db.model.buildrequests
+                buildset_properties_tbl = self.db.model.buildset_properties
+                from_clause = builds_tbl.join(
+                    buildrequests_tbl,
+                    buildrequests_tbl.c.id == builds_tbl.c.buildrequestid,
+                )
+                from_clause = from_clause.join(
+                    buildset_properties_tbl,
+                    buildset_properties_tbl.c.buildsetid == buildrequests_tbl.c.buildsetid,
+                )
+                q = (
+                    sa
+                    .select(builds_tbl.c.number, builds_tbl.c.results)
+                    .select_from(from_clause)
+                    .where(
+                        (builds_tbl.c.builderid == builderid)
+                        & (builds_tbl.c.number < number)
+                        & (builds_tbl.c.results != RETRY)
+                        & (builds_tbl.c.results != SKIPPED)
+                        & (builds_tbl.c.results != CANCELLED)
+                        & (buildset_properties_tbl.c.property_name == "scheduler")
+                        # buildset_properties_tbl.c.property_value is a tuple '["name...", "Scheduler"]'
+                        & buildset_properties_tbl.c.property_value.startswith(
+                            f'["{scheduler_filter}'
+                        )
+                    )
+                    .order_by(sa.desc(builds_tbl.c.number))
+                    .limit(1)
+                )
+            else:
+                q = (
+                    sa
+                    .select(builds_tbl.c.number, builds_tbl.c.results)
+                    .select_from(builds_tbl)
+                    .where(
+                        (builds_tbl.c.builderid == builderid)
+                        & (builds_tbl.c.number < number)
+                        & (builds_tbl.c.results != RETRY)
+                        & (builds_tbl.c.results != SKIPPED)
+                        & (builds_tbl.c.results != CANCELLED)
+                    )
+                    .order_by(sa.desc(builds_tbl.c.number))
+                    .limit(1)
+                )
+
+            # qc = q.compile(compile_kwargs={"literal_binds": True})
+            # log.msg(f"DEBUG: getPreviousBuild: SQL request: {qc}")
+            row = conn.execute(q).first()
+            return (row.number, row.results) if row is not None else (None, None)
+
+        return self.db.pool.do(thd)
+
+    def getNextBuild(
+        self, builderid: int, number: int, scheduler_filter: str | None = None
+    ) -> defer.Deferred[tuple[int | None, int | None]]:
+        def thd(conn: sa.engine.Connection) -> tuple[int | None, int | None]:
+            builds_tbl = self.db.model.builds
+            if scheduler_filter:
+                buildrequests_tbl = self.db.model.buildrequests
+                buildset_properties_tbl = self.db.model.buildset_properties
+                from_clause = builds_tbl.join(
+                    buildrequests_tbl,
+                    buildrequests_tbl.c.id == builds_tbl.c.buildrequestid,
+                )
+                from_clause = from_clause.join(
+                    buildset_properties_tbl,
+                    buildset_properties_tbl.c.buildsetid == buildrequests_tbl.c.buildsetid,
+                )
+                q = (
+                    sa
+                    .select(builds_tbl.c.id, builds_tbl.c.results)
+                    .select_from(from_clause)
+                    .where(
+                        (builds_tbl.c.builderid == builderid)
+                        & (builds_tbl.c.number > number)
+                        & (builds_tbl.c.results != RETRY)
+                        & (builds_tbl.c.results != SKIPPED)
+                        & (builds_tbl.c.results != CANCELLED)
+                        & (buildset_properties_tbl.c.property_name == "scheduler")
+                        # buildset_properties_tbl.c.property_value is a tuple '["name...", "Scheduler"]'
+                        & buildset_properties_tbl.c.property_value.startswith(
+                            f'["{scheduler_filter}'
+                        )
+                    )
+                    .order_by(builds_tbl.c.number)
+                    .limit(1)
+                )
+            else:
+                q = (
+                    sa
+                    .select(builds_tbl.c.id, builds_tbl.c.results)
+                    .select_from(builds_tbl)
+                    .where(
+                        (builds_tbl.c.builderid == builderid)
+                        & (builds_tbl.c.number > number)
+                        & (builds_tbl.c.results != RETRY)
+                        & (builds_tbl.c.results != SKIPPED)
+                        & (builds_tbl.c.results != CANCELLED)
+                    )
+                    .order_by(builds_tbl.c.number)
+                    .limit(1)
+                )
+
+            # qc = q.compile(compile_kwargs={"literal_binds": True})
+            # log.msg(f"DEBUG: getPreviousBuild: SQL request: {qc}")
+            row = conn.execute(q).first()
+            return (row.id, row.results) if row is not None else (None, None)
+
+        return self.db.pool.do(thd)
+    #LLVM_LOCAL_END
+    
     def getBuildsForChange(self, changeid):
         assert changeid > 0
 

--- a/master/buildbot/reporters/base.py
+++ b/master/buildbot/reporters/base.py
@@ -19,6 +19,7 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot import config
+from buildbot.process.results import FAILURE
 from buildbot.reporters import utils
 from buildbot.util import service
 from buildbot.util import tuplematch
@@ -116,6 +117,53 @@ class ReporterBase(service.BuildbotService):
                     except Exception as e:
                         log.err(e, "Got exception when handling reporter events: "
                                 f"key: {key} generator: {g}")
+
+            #LLVM_LOCAL_BEGIN
+            if (
+                tuplematch.matchTuple(key, ("builds", None, "finished"))
+                and msg.get("builderid") is not None
+                and msg.get("number") is not None
+                and msg.get("results") is not None
+            ):
+                # Check if there is the next completed build.
+                next_build_id, next_build_results = (
+                    yield self.master.db.builds.getNextBuild(
+                        builderid=msg["builderid"],
+                        number=msg["number"],
+                        scheduler_filter="main:",
+                    )
+                )
+                # Process reports for the mode change or problem.
+                if (
+                    next_build_id is not None
+                    and next_build_results is not None
+                    and (
+                        next_build_results != msg["results"]
+                        or next_build_results == FAILURE
+                    )
+                ):
+                    next_build = yield self.master.data.get(
+                        ("builds", str(next_build_id))
+                    )
+                    for g in self.generators:
+                        if (
+                            self._does_generator_want_key(g, key)
+                            and hasattr(g.__class__, "_want_previous_build")
+                            and g._want_previous_build()
+                        ):
+                            try:
+                                report = yield g.generate(
+                                    self.master, self, key, next_build
+                                )
+                                if report is not None:
+                                    reports.append(report)
+                            except Exception as e:
+                                log.err(
+                                    e,
+                                    "Got exception when handling reporter events: "
+                                    f"key: {key} generator: {g}",
+                                )
+            #LLVM_LOCAL_END
 
             if reports:
                 yield self.sendMessage(reports)

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -109,7 +109,7 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
     def _is_message_needed_by_results(self, build):
         results = build['results']
         if "change" in self.mode:
-            prev = build['prev_build']
+            prev = build.get('prev_build')
             if prev and prev['results'] != results:
                 return True
         if "failing" in self.mode and results == FAILURE:
@@ -117,7 +117,8 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
         if "passing" in self.mode and results == SUCCESS:
             return True
         if "problem" in self.mode and results == FAILURE:
-            prev = build['prev_build']
+            prev = build.get('prev_build')
+            # prev is None if the previous build is incomplete yet
             if prev and prev['results'] in [SUCCESS, WARNINGS]:  # != FAILURE:
                 return True
         if "warnings" in self.mode and results == WARNINGS:

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -20,41 +20,22 @@ from twisted.python import log
 
 from buildbot.data import resultspec
 from buildbot.process.properties import renderer
-from buildbot.process.results import RETRY, SKIPPED, CANCELLED # LLVM_LOCAL
 from buildbot.util import flatten
 
 
 @defer.inlineCallbacks
 def getPreviousBuild(master, build):
-    # naive n-1 algorithm. Still need to define what we should skip
-    # SKIP builds? forced builds? rebuilds?
-    # don't hesitate to contribute improvements to that algorithm
-    n = build['number'] - 1
-    while n >= 0:
-        prev = yield master.data.get(("builders", build['builderid'], "builds", n))
+    #LLVM_LOCAL_BEGIN
+    builderid = build["builderid"]
+    prev_build_number, prev_build_results = yield master.db.builds.getPrevBuild(
+        builderid, build["number"], "main:"
+    )
+    # If results is None it means that the previous build is incomplete yet.
+    if prev_build_number is not None and prev_build_results is not None:
+        prev_build = yield master.data.get(("builders", builderid, "builds", prev_build_number))
+        return prev_build
+    #LLVM_LOCAL_END
 
-        # LLVM_LOCAL begin
-        if prev:
-            # Probably we just need to specify schedulers for each MailNotifier!
-
-            # ForceSchedulers starts with "force-...".
-            # getReleaseBranchSchedulers() creates schedulers like "release:...".
-            # getMainBranchSchedulers() creates schedulers like
-            # "main:clang,clang-tools-extra,compiler-rt,libcxx,libcxxabi,libunwind,lld,llvm,mlir".
-            prev_scheduler = prev['properties'].get('scheduler', ["(unknown)"])[0]
-
-            # We can also use the reason:
-            # prev_reason = prev['properties'].get('reason', ["(unknown)"])[0]
-            if (
-            	# Look at builds requested only by schedulers created with getMainBranchSchedulers().
-            	# Or we can search the same scheduler for the prev build.
-                prev_scheduler.startswith("main:") and
-                # not prev_reason.startswith("A build was forced by") and
-                prev['results'] not in [RETRY, SKIPPED, CANCELLED] # != RETRY
-            ):  
-                return prev
-        # LLVM_LOCAL end
-        n -= 1
     return None
 
 


### PR DESCRIPTION
The current implementation of `getPreviousBuild()` may cause catastrophic performance degradation in high-load systems. The `getPreviousBuild()` method has been refactored to use a single query to find the previous build number. Additionally the ability to filter out builds by the scheduler has been added. This allows to ignore manually triggered builds.

The previous incomplete build is currently considered successful in `is_message_needed_by_results()`. Now `getPreviousBuild()` returns None for incomplete builds (results is None). When the previous build will be finished, `_got_event()` will call `getNextBuild()` and ask for the report from generators which have `_want_previous_build()` (BuildStatusGenerator) and _want_previous_build() is True (mode=problem).