### PR TITLE
[4.x] Handle utf-8 decoding problems with strings we get from remote parties.

### DIFF
--- a/master/buildbot/pbutil.py
+++ b/master/buildbot/pbutil.py
@@ -149,7 +149,12 @@ class ReconnectingPBClientFactory(PBClientFactory, protocol.ReconnectingClientFa
         log.err(why)
 
 
-def decode(data, encoding='utf-8', errors='strict'):
+# LLVM_LOCAL begin
+# TODO: Hack the error mode. Later address this properly to pass input
+# parameters down to map. We cannot trust strings we are getting
+# from users, but need to recover preserving as much as we could.
+def decode(data, encoding='utf-8', errors='replace'):
+# LLVM_LOCAL end
     """We need to convert a dictionary where keys and values
     are bytes, to unicode strings.  This happens when a
     Python 2 worker sends a dictionary back to a Python 3 master.


### PR DESCRIPTION
Based on https://github.com/gkistanova/buildbot/commit/baaede4e274c5225416f7fac0e379fc025c2fb0a

Note using `decode(info, 'replace')` in `llvm/3.x` code is the bug!
