### PR TITLE
[4.x] Support the parameter ignoreOfflineWorkersTimeout in master.cfg

### DIFF
--- a/master/buildbot/config/master.py
+++ b/master/buildbot/config/master.py
@@ -204,6 +204,8 @@ class MasterConfig(util.ComparableMixin):
         self.protocols = {}
         self.buildbotNetUsageData = "basic"
 
+        self.ignoreOfflineWorkersTimeout = None #LLVM_LOCAL
+
         self.validation = {
             "branch": re.compile(r'^[\w.+/~-]*$'),
             "revision": re.compile(r'^[ \w\.\-/]*$'),
@@ -249,6 +251,7 @@ class MasterConfig(util.ComparableMixin):
         "changeHorizon",
         'db',
         "db_url",
+        "ignoreOfflineWorkersTimeout", #LLVM_LOCAL
         "logCompressionLimit",
         "logCompressionMethod",
         "logEncoding",
@@ -420,6 +423,8 @@ class MasterConfig(util.ComparableMixin):
 
         copy_int_param('changeHorizon')
         copy_int_param('logCompressionLimit')
+
+        copy_int_param('ignoreOfflineWorkersTimeout') #LLVM_LOCAL
 
         self.logCompressionMethod = config_dict.get(
             'logCompressionMethod',

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -25,6 +25,7 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot import interfaces
+from buildbot import util #LLVM_LOCAL
 from buildbot.data import resultspec
 from buildbot.interfaces import IRenderable
 from buildbot.process import buildrequest
@@ -92,6 +93,13 @@ class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
         # Tracks config version for locks
         self.config_version = None
 
+        #LLVM_LOCAL_BEGIN
+        # Do not ignore offline builders within the timeout after reboot.
+        # Use self._last_detached_time=0 to ignore all builders after reboot till attach the first worker.
+        self._last_detached_time = util.now()
+        self._ignore_offline_workers_timeout = None
+        #LLVM_LOCAL_END
+
     def _find_builder_config_by_name(self, new_config: MasterConfig) -> BuilderConfig | None:
         for builder_config in new_config.builders:
             if builder_config.name == self.name:
@@ -138,6 +146,17 @@ class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
         # drop them.
         new_workernames = set(builder_config.workernames)
         self.workers = [w for w in self.workers if w.worker.workername in new_workernames]
+
+        #LLVM_LOCAL_BEGIN
+        # Note ignoreOfflineWorkersTimeout=0 means do not use timeout.
+        self._ignore_offline_workers_timeout = (
+            new_config.ignoreOfflineWorkersTimeout * 60
+            if new_config.ignoreOfflineWorkersTimeout
+            else None
+        )
+        if new_config.ignoreOfflineWorkersTimeout is None:
+            log.msg("WARNING: 'ignoreOfflineWorkersTimeout' is missing in master.cfg")
+        #LLVM_LOCAL_END
 
     def _has_updated_config_info(self, old_config, new_config):
         if old_config is None:
@@ -315,6 +334,20 @@ class Builder(util_service.ReconfigurableServiceMixin, service.MultiService):
 
         # inform the WorkerForBuilder that their worker went away
         wfb.detached()
+
+        self._last_detached_time = util.now() #LLVM_LOCAL
+
+    #LLVM_LOCAL_BEGIN
+    def workersAvailable(self):
+        if (
+            self.workers
+            or self._ignore_offline_workers_timeout is None
+            or self._last_detached_time is None
+        ):
+            return True
+        offline_workers_duration = util.now() - self._last_detached_time
+        return offline_workers_duration < self._ignore_offline_workers_timeout
+    #LLVM_LOCAL_END
 
     def getAvailableWorkers(self):
         return [wfb for wfb in self.workers if wfb.isAvailable()]

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -899,7 +899,14 @@ class ReconfigurableBaseScheduler(ClusteredBuildbotService, StateMixin):
         builderids = []
         for bldr in (yield self.master.data.get(('builders',))):
             if bldr['name'] in builderNames:
-                builderids.append(bldr['builderid'])
+                #LLVM_LOCAL_BEGIN
+                bldr_obj = self.master.botmaster.builders.get(bldr['name'])
+                # Check the attribute to make tests with mock Builder happy.
+                if not hasattr(bldr_obj.__class__, "workersAvailable") or bldr_obj.workersAvailable():
+                    builderids.append(bldr['builderid'])
+                else:
+                    log.msg(f">>> addBuildsetForSourceStamps: Ignore builder {bldr['name']} because of offline workers.")
+                #LLVM_LOCAL_END
 
         # translate properties object into a dict as required by the
         # addBuildset method


### PR DESCRIPTION
ignoreOfflineWorkersTimeout=60 means do not create build requests for builders which have no active workers more than 60 minutes. ignoreOfflineWorkersTimeout=0 disables this feature.

Based on #12.