### PR TITLE
[4.x] Fixed unexpected hang on doReconfig

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -57,7 +57,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
     def __init__(self, owner: str, slug: str, **kwargs: Any):
         kwargs['name'] = self.build_name(owner, slug)
 
-        self.initLock = defer.DeferredLock()
+        self.initLock2 = defer.DeferredLock() #LLVM_LOCAL
 
         super().__init__(owner, slug, **kwargs)
 
@@ -131,7 +131,7 @@ class BitbucketPullrequestPoller(base.ReconfigurablePollingChangeSource, PullReq
         )
 
     # mypy: disable-error-code="override"
-    @deferredLocked('initLock')
+    @deferredLocked('initLock2') #LLVM_LOCAL
     @defer.inlineCallbacks
     def poll(self) -> InlineCallbacksType[None]:  # type: ignore[override]
         response = yield self._getChanges()

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -64,7 +64,7 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
             branches = self.build_branches(kwargs.get('branch', None), kwargs.get('branches', None))
             kwargs["name"] = self.build_name(None, repourl, kwargs.get('bookmarks', None), branches)
 
-        self.initLock = defer.DeferredLock()
+        self.initLock3 = defer.DeferredLock() #LLVM_LOCAL
 
         super().__init__(repourl, **kwargs)
 
@@ -193,7 +193,7 @@ class HgPoller(base.ReconfigurablePollingChangeSource, StateMixin):
             f"branches: {', '.join(self.branches)}, in workdir '{self.workdir}' {status}"
         )
 
-    @deferredLocked('initLock')
+    @deferredLocked('initLock3') #LLVM_LOCAL
     @defer.inlineCallbacks
     def poll(self) -> InlineCallbacksType[None]:  # type: ignore[override]
         yield self._getChanges()


### PR DESCRIPTION
`yield self.initLock.acquire()` in doReconfig may hang. Probably `getattr(args[0], lock)` in the decorator @deferredLocked got `self.master.initLock` instead of `self.initLock` somehow in some cases.

Based on #3.
